### PR TITLE
fix: exclude `sismo-connect-server` from NextJS custom bundling

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  webpack: (config) => {
-    config.resolve.fallback = { "utf-8-validate": false, bufferutil: false };
-    config.experiments = {
-      ...config.experiments,
-    };
-    return config;
+  experimental: {
+    serverComponentsExternalPackages: ["@sismo-core/sismo-connect-server"],
   },
-};
+}
 
-module.exports = nextConfig;
+module.exports = nextConfig


### PR DESCRIPTION
## Context

Fixes hanging server-side verification in release mode that is likely to be caused by how NextJS bundles `sismo-connect-server` package.